### PR TITLE
Re-organize <head> orders, sort element by their priority

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>baksla.sh</title>
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="assets/css/style.built.css">
+
+    <!-- Scripts -->
+    <script src="assets/js/index.js" defer></script>
+
     <meta name="description" content="A real OSS company, Symfony evangelist with pragmatic technologists">
 
     <!-- Opengraph Meta Tags -->
@@ -13,7 +20,7 @@
     <meta property="og:title" content="baksla.sh">
     <meta property="og:description" content="A real OSS company, Symfony evangelist with pragmatic technologists">
     <meta property="og:image" content="https://baksla.sh/assets/image/bakslash.svg">
-    
+
     <!-- X Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="baksla.sh">
@@ -22,16 +29,10 @@
     <meta name="twitter:description" content="A real OSS company, Symfony evangelist with pragmatic technologists">
     <meta name="twitter:image" content="https://baksla.sh/assets/image/bakslash.svg">
 
-    <link rel="preload" href="assets/image/code.png" as="image">
-    <link rel="stylesheet" href="assets/css/style.built.css">
-
     <!-- Favicon links -->
     <link rel="icon" type="image/png" href="assets/image/favicon-96x96.png" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="assets/image/favicon.svg">
     <link rel="shortcut icon" href="assets/image/favicon.ico">
-
-    <!-- External scripts -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 
 <body class="bg-gray-100">
@@ -332,7 +333,5 @@
             </ul>
         </div>
     </footer>
-
-    <script type="text/javascript" src="assets/js/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Mini-PR sur les perfs fronts.

C'est léger, mais l'ordre des éléments dans le `<head>` a une importance pour rendre la page le mieux possible, ils ont chacun une priorités : 
1. le charset et le viewport
2. le titre du document
3. les styles
4. les scripts (en defer, ne bloquant pas le rendu de la page)
5. les diverses meta-données (og, twitter, icons, json+ld, ...)

Actuellement : 
<img width="559" alt="Capture d’écran 2024-11-28 à 20 26 15" src="https://github.com/user-attachments/assets/a3225a4a-a41f-4eb1-b824-8e6713250f8a">


Avec cette PR : 
<img width="969" alt="image" src="https://github.com/user-attachments/assets/88f933d3-f596-4e31-a501-47277ebd1c59">

---

J'utilise https://chromewebstore.google.com/detail/capo-get-your-%EF%B9%A4%F0%9D%9A%91%F0%9D%9A%8E%F0%9D%9A%8A%F0%9D%9A%8D%EF%B9%A5/ohabpnaccigjhkkebjofhpmebofgpbeb pour m'aider à trier le `<head>`, je l'avais utilisé à Wamiz et de mémoire ça avait bien aidé :) 