### PR TITLE
Fix: use png images instead svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="baksla.sh">
     <meta property="og:description" content="A real OSS company, Symfony evangelist with pragmatic technologists">
-    <meta property="og:image" content="https://baksla.sh/assets/image/bakslash.svg">
+    <meta property="og:image" content="https://baksla.sh/assets/image/bakslash.png">
 
     <!-- X Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -27,7 +27,7 @@
     <meta property="twitter:url" content="https://baksla.sh">
     <meta name="twitter:title" content="baksla.sh">
     <meta name="twitter:description" content="A real OSS company, Symfony evangelist with pragmatic technologists">
-    <meta name="twitter:image" content="https://baksla.sh/assets/image/bakslash.svg">
+    <meta name="twitter:image" content="https://baksla.sh/assets/image/bakslash.png">
 
     <!-- Favicon links -->
     <link rel="icon" type="image/png" href="assets/image/favicon-96x96.png" sizes="96x96">


### PR DESCRIPTION
Opengraph doesn’t supports svg images after investigation 
https://indieweb.org/The-Open-Graph-protocol#Does_not_support_SVG_images