### PR TITLE
Re-ogranize <head> and put scripts tags before metadata and icons

### DIFF
--- a/templates/pages/base.html.twig
+++ b/templates/pages/base.html.twig
@@ -23,6 +23,11 @@
             </style>
         {% endblock %}
 
+        <!-- Scripts -->
+        {% block javascripts %}
+            {% block importmap %}{{ importmap('app') }}{% endblock %}
+        {% endblock %}
+
         <!-- Metadata & cie -->
         {% block seo %}
         {% endblock %}
@@ -31,10 +36,6 @@
         <link rel="icon" type="image/png" href="{{ asset('images/favicon-96x96.png') }}" sizes="96x96">
         <link rel="icon" type="image/svg+xml" href="{{ asset('images/favicon.svg') }}">
         <link rel="shortcut icon" href="{{ asset('images/favicon.ico') }}">
-
-        {% block javascripts %}
-            {% block importmap %}{{ importmap('app') }}{% endblock %}
-        {% endblock %}
     </head>
     <body class="bg-white min-h-screen flex flex-col">
         <div data-controller="analytics" data-analytics-measurement-id-value="{{ ga_measurement_id }}" data-analytics-app-name-value="{{ ga_app_name }}"></div>


### PR DESCRIPTION
Like #16... :D 

Actually:
<img width="1338" alt="Capture d’écran 2025-02-26 à 22 17 33" src="https://github.com/user-attachments/assets/2ec71223-a2a0-43f6-a97c-e61ccfd339c3" />

After:
<img width="842" alt="Capture d’écran 2025-02-26 à 22 15 23" src="https://github.com/user-attachments/assets/65a08625-d3b5-40e8-9ddc-bbd5c657d064" />

Metadata things must really be the last elements of `<head>`, in order to prioritize more critical elements like critical CSS, CSS, scripts, etc... 