### PR TITLE
Define `lazyLoadImage` property on `ArticlePreview` component

### DIFF
--- a/src/Blog/Infrastructure/Twig/Components/ArticlePreview.php
+++ b/src/Blog/Infrastructure/Twig/Components/ArticlePreview.php
@@ -19,6 +19,8 @@ final class ArticlePreview
 
     public Author $author;
 
+    public bool $lazyLoadImage = false;
+
     public function mount(ArticlePreviewModel $article): void
     {
         $this->id = $article->id;

--- a/templates/components/blog/ArticlePreview.html.twig
+++ b/templates/components/blog/ArticlePreview.html.twig
@@ -26,7 +26,7 @@
             <h2 class="text-xl font-semibold text-slate-900 pb-3 sm:text-xl">{{ title }}</h2>
             <p class="text-gray-900">{{ description }}</p>
             <div class="mt-6 flex items-center gap-x-4">
-                <img class="size-10 rounded-full bg-gray-50" src="{{ asset('images/blog/author/' ~ author.picture) }}" alt="{{ author.name }}" {% if _context['lazy-load-image'] is defined %}loading="lazy"{% endif %} />
+                <img class="size-10 rounded-full bg-gray-50" src="{{ asset('images/blog/author/' ~ author.picture) }}" alt="{{ author.name }}" {% if lazyLoadImage %}loading="lazy"{% endif %} />
 
                 <div class="flex-auto">
                     <div class="font-semibold">{{ author.name }}</div>

--- a/templates/pages/blog/article.html.twig
+++ b/templates/pages/blog/article.html.twig
@@ -47,7 +47,7 @@
             <div class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-8 pt-10 lg:mx-0 lg:max-w-none lg:grid-cols-3" data-test-more-articles>
                 {% for preview in more %}
                     {% if preview %}
-                        <twig:ArticlePreview :article="preview" lazy-load-image />
+                        <twig:ArticlePreview :article="preview" lazyLoadImage />
                     {% else %}
                         <twig:blog:ArticlePreviewPlaceholder />
                     {% endif %}

--- a/templates/pages/blog/index.html.twig
+++ b/templates/pages/blog/index.html.twig
@@ -41,7 +41,7 @@
                     <div class="space-y-8 xl:row-span-2">
                         {% if articles %}
                             {% for i, article in articles|filter((_, i) => i % 4 == 0) %}
-                                <twig:ArticlePreview :article="article" :lazy-load-image="i > 7" />
+                                <twig:ArticlePreview :article="article" :lazyLoadImage="i > 7" />
                             {% endfor %}
                         {% else %}
                             <twig:blog:ArticlePreviewPlaceholder />
@@ -51,7 +51,7 @@
                     <div class="space-y-8 xl:row-start-1">
                         {% if articles %}
                             {% for i, article in articles|filter((_, i) => i % 4 == 1) %}
-                                <twig:ArticlePreview :article="article" :lazy-load-image="i > 7" />
+                                <twig:ArticlePreview :article="article" :lazyLoadImage="i > 7" />
                             {% endfor %}
                         {% else %}
                             <twig:blog:ArticlePreviewPlaceholder />
@@ -64,7 +64,7 @@
                     <div class="space-y-8 xl:row-start-1">
                         {% if articles %}
                             {% for i, article in articles|filter((_, i) => i % 4 == 2) %}
-                                <twig:ArticlePreview :article="article" :lazy-load-image="i > 7" />
+                                <twig:ArticlePreview :article="article" :lazyLoadImage="i > 7" />
                             {% endfor %}
                         {% else %}
                             <twig:blog:ArticlePreviewPlaceholder class="max-sm:hidden" />
@@ -74,7 +74,7 @@
                     <div class="space-y-8 xl:row-span-2">
                         {% if articles %}
                             {% for i, article in articles|filter((_, i) => i % 4 == 2) %}
-                                <twig:ArticlePreview :article="article" :lazy-load-image="i > 7" />
+                                <twig:ArticlePreview :article="article" :lazyLoadImage="i > 7" />
                             {% endfor %}
                         {% else %}
                             <twig:blog:ArticlePreviewPlaceholder class="max-xl:hidden" />


### PR DESCRIPTION
It was maybe done on purpose (since we already have defined props), but using `_context` instead of a true prop feels wrong to me