### PR TITLE
config: pin Biome.js version to 1.9.4

### DIFF
--- a/config/packages/kocal_biome_js.yaml
+++ b/config/packages/kocal_biome_js.yaml
@@ -1,3 +1,3 @@
 when@dev:
     kocal_biome_js:
-        binary_version: 'latest_stable'
+        binary_version: 'v1.9.4'


### PR DESCRIPTION
This way, we prevent unecessary requests to GitHub when running BiomeJsBundle. 