### PR TITLE
[Home] Reorder KPIs

### DIFF
--- a/templates/pages/website/home/_kpi.html.twig
+++ b/templates/pages/website/home/_kpi.html.twig
@@ -16,10 +16,10 @@
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
         <div class="container max-w-screen-xl mx-auto">
             <div class="mt-8 grid grid-cols-2 max-sm:gap-0.5 overflow-hidden rounded-2xl text-center sm:grid-cols-2 lg:grid-cols-5">
-                {{ _self.kpi(name: 'home.kpi.talks'|trans, value: '20+', icon: 'logos:php', iconLabel: 'PHP') }}
-                {{ _self.kpi(name: 'home.kpi.core_team'|trans, value: '3', icon: 'logos:symfony', iconLabel: 'Symfony') }}
-                {{ _self.kpi(name: 'home.kpi.projects'|trans, value: '15', icon: 'ix:project-simulation', iconLabel: 'Projects') }}
+                {{ _self.kpi(name: 'home.kpi.projects'|trans, value: '15+', icon: 'ix:project-simulation', iconLabel: 'Projects') }}
                 {{ _self.kpi(name: 'home.kpi.collaborators'|trans, value: '9', icon: 'mdi:duck', iconLabel: 'Collaborators') }}
+                {{ _self.kpi(name: 'home.kpi.core_team'|trans, value: '3', icon: 'logos:symfony', iconLabel: 'Symfony') }}
+                {{ _self.kpi(name: 'home.kpi.talks'|trans, value: '20+', icon: 'logos:php', iconLabel: 'PHP') }}
                 {{ _self.kpi(name: 'home.kpi.love_in_ecosystem'|trans, value: '∞', icon: 'noto:red-heart', iconLabel: 'love', class: 'col-span-2 sm:col-span-4 lg:col-span-1') }}
             </div>
         </div>


### PR DESCRIPTION
Showcasing the most business-relevant figures first.

Before:
<img width="1240" alt="Screenshot 2025-04-18 at 17 30 54" src="https://github.com/user-attachments/assets/22cf4de3-25a4-4b38-87e4-d0538affb634" />

After:
<img width="1252" alt="Screenshot 2025-04-18 at 17 31 12" src="https://github.com/user-attachments/assets/461542ba-c648-41e2-974e-4d5753c9b002" />
