### PR TITLE
Fix Tailwind `content` configuration with invalid path to `LeagueMarkdownConverter.php`

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./assets/**/*.js', './templates/**/*.html.twig', './src/Blog/Infrastructure/League/CommonMark/LeagueMarkdownConverter.php'],
+  content: ['./assets/**/*.js', './templates/**/*.html.twig', './src/Blog/Infrastructure/Rendering/LeagueMarkdownConverter.php'],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
Otherwise the styles generated for blog pages is not correct (since CSS classes are missing)