### PR TITLE
Fix member modal centering on mobile

### DIFF
--- a/templates/components/Team/MemberModal.html.twig
+++ b/templates/components/Team/MemberModal.html.twig
@@ -7,7 +7,7 @@
     data-member-modal-prev-value="{{ prev }}"
     data-member-modal-next-value="{{ next }}"
     data-action="cancel->member-modal#onCancel"
-    class="bg-transparent p-0 w-screen max-w-none max-h-none h-screen backdrop:bg-ink/55 backdrop:backdrop-blur-md"
+    class="bg-transparent p-0 w-dvw max-w-none max-h-none h-dvh backdrop:bg-ink/55 backdrop:backdrop-blur-md"
 >
     <div
         data-action="click->member-modal#close:self"
@@ -15,7 +15,7 @@
     >
         <div
             data-member-modal-target="modal"
-            class="relative w-full max-w-4xl max-h-[85vh] flex flex-col bg-paper rounded-2xl overflow-hidden shadow-2xl border border-ink/15 transition-all ease-out duration-300 opacity-0 translate-y-4 scale-95"
+            class="relative w-full max-w-4xl max-h-[85dvh] flex flex-col bg-paper rounded-2xl overflow-hidden shadow-2xl border border-ink/15 transition-all ease-out duration-300 opacity-0 translate-y-4 scale-95"
         >
             <button
                 type="button"


### PR DESCRIPTION
Use dynamic viewport units instead of vw/vh so the dialog sizes against the visible viewport rather than the large viewport, which excludes the iOS Safari URL bar from the centering calculation.