### PR TITLE
Enhance member modal by adding a blurred background image

### DIFF
--- a/templates/components/Team/MemberModal.html.twig
+++ b/templates/components/Team/MemberModal.html.twig
@@ -15,7 +15,7 @@
     >
         <div
             data-member-modal-target="modal"
-            class="relative w-full max-w-4xl max-h-[85dvh] flex flex-col bg-paper rounded-2xl overflow-hidden shadow-2xl border border-ink/15 transition-all ease-out duration-300 opacity-0 translate-y-4 scale-95"
+            class="relative w-full max-w-4xl max-h-[85dvh] flex flex-col bg-paper rounded-2xl overflow-hidden shadow-2xl transition-all ease-out duration-300 opacity-0 translate-y-4 scale-95"
         >
             <button
                 type="button"
@@ -36,13 +36,18 @@
 
             <div class="flex-1 overflow-y-auto">
                 <div class="grid grid-cols-1 md:grid-cols-[18rem_1fr] md:min-h-[24rem]">
-                    <div class="relative bg-ink overflow-hidden h-40 md:h-auto md:min-h-[14rem]">
+                    <div class="relative overflow-hidden h-40 md:h-auto md:min-h-[14rem]">
                         <img
-                            class="absolute inset-0 size-full object-cover"
+                            class="absolute inset-0 size-full scale-120 object-cover blur-2xl opacity-70"
                             src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
                             alt=""
                         />
                         <div aria-hidden="true" class="absolute inset-0 bg-gradient-to-t from-ink via-ink/40 to-transparent"></div>
+                        <img
+                            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full max-h-[80%] max-w-[80%] shadow-lg"
+                            src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
+                            alt="Photo of {{ member.fullName }}"
+                        />
                         {% if member.nickName %}
                             <div class="absolute bottom-5 left-5 right-5 text-paper">
                                 <div class="font-sans italic text-paper/80 text-sm">“{{ member.nickName }}”</div>


### PR DESCRIPTION
Sur la page Crew, suite à la refonte, les photos (au format carré) ont du mal à s'afficher dans les modales adéquates. Des fois c'est ok : 
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 22 08" src="https://github.com/user-attachments/assets/9093fabe-d058-422e-b526-b6b6b3972cc6" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 21 32" src="https://github.com/user-attachments/assets/d6c5b85f-b3a4-4dbe-94bc-4806f7d98779" />

mais des fois non : 
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 21 45" src="https://github.com/user-attachments/assets/93c04f5c-e36e-43bf-baed-ae014dead11c" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 21 36" src="https://github.com/user-attachments/assets/7630ea3e-8bde-4403-a65c-8ecf1a86e425" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 21 25" src="https://github.com/user-attachments/assets/2da7119a-7c7b-40ea-8d8f-d30fe84a67f3" />

Avec cette PR, j'essaye d'améliorer l'affichage des photos, ça donne ça : 

<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 30 31" src="https://github.com/user-attachments/assets/7604d9d7-10e5-47b0-8e57-61a63f74d0ae" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 30 28" src="https://github.com/user-attachments/assets/9f293ce3-e081-4d2b-b2e2-f2f7674b3f33" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 30 21" src="https://github.com/user-attachments/assets/76d80920-9595-48b4-9988-3824444c3a42" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 30 17" src="https://github.com/user-attachments/assets/76e8d7a9-67b2-4708-8fca-969d6400e0a7" />
<img width="1912" height="1242" alt="Capture d’écran 2026-05-18 à 20 30 13" src="https://github.com/user-attachments/assets/34ca6b87-44da-4801-a9f8-a7516b92d458" />
