### PR TITLE
Change prose code symbol color to white

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -190,7 +190,7 @@
 
   .prose-body .hl-attribute,
   .prose-body .hl-symbol {
-    color: var(--color-accent);
+    color: #fff;
   }
 
   .pr-code .hl-keyword {


### PR DESCRIPTION
Avant :
<img width="741" height="217" alt="Capture d’écran 2026-05-18 à 20 43 33" src="https://github.com/user-attachments/assets/b997af06-3b14-406c-b5e1-1c4e5e00fb65" />


Après : 
<img width="755" height="217" alt="image" src="https://github.com/user-attachments/assets/23cd672e-9bd6-42fa-a572-bc7ebfcd53df" />
