### PR TITLE
Do not remove document tags from from minified HTML, some `og:image` improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "league/commonmark": "^2.8.2",
         "phpdocumentor/reflection-docblock": "^5.6.7",
         "phpstan/phpdoc-parser": "^2.3.2",
-        "sensiolabs/minify-bundle": "^1.2.0",
+        "sensiolabs/minify-bundle": "dev-feat/html-support as 1.3.0",
         "symfony/asset": "8.0.*",
         "symfony/asset-mapper": "8.0.*",
         "symfony/cache": "8.0.*",
@@ -104,6 +104,12 @@
             "docker": true
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/bakslashHQ/minify-bundle"
+        }
+    ],
     "require-dev": {
         "kocal/biome-js-bundle": "^2.1.2",
         "phpstan/phpstan": "^2.1.46",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "602c28fa26eca4c6edaaccd0f79ac7fc",
+    "content-hash": "5f119dd1c63b2f6459060d12c36a4bc8",
     "packages": [
         {
             "name": "composer/semver",
@@ -1249,16 +1249,16 @@
         },
         {
             "name": "sensiolabs/minify-bundle",
-            "version": "v1.2.0",
+            "version": "dev-feat/html-support",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sensiolabs/minify-bundle.git",
-                "reference": "cf6462fbbd7883367c6ee1f02424e93a3df79384"
+                "url": "https://github.com/bakslashHQ/minify-bundle.git",
+                "reference": "d1f26e79afea0595ff7ef95d97fbff00a528134f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/minify-bundle/zipball/cf6462fbbd7883367c6ee1f02424e93a3df79384",
-                "reference": "cf6462fbbd7883367c6ee1f02424e93a3df79384",
+                "url": "https://api.github.com/repos/bakslashHQ/minify-bundle/zipball/d1f26e79afea0595ff7ef95d97fbff00a528134f",
+                "reference": "d1f26e79afea0595ff7ef95d97fbff00a528134f",
                 "shasum": ""
             },
             "require": {
@@ -1280,8 +1280,8 @@
             "type": "symfony-bundle",
             "extra": {
                 "thanks": {
-                    "url": "https://github.com/tdewolff/minify",
-                    "name": "tdewolff/minify"
+                    "name": "tdewolff/minify",
+                    "url": "https://github.com/tdewolff/minify"
                 }
             },
             "autoload": {
@@ -1289,7 +1289,11 @@
                     "Sensiolabs\\MinifyBundle\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Sensiolabs\\MinifyBundle\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -1306,21 +1310,20 @@
             "description": "Assets Minifier (CSS, JS) for Symfony & Minify integration in Asset Mapper",
             "homepage": "https://github.com/sensiolabs/minify-bundle",
             "keywords": [
-                "JS",
                 "asset-mapper",
                 "assets",
                 "compress",
                 "css",
+                "js",
                 "minifier",
                 "minify",
                 "symfony",
                 "uglify"
             ],
             "support": {
-                "issues": "https://github.com/sensiolabs/minify-bundle/issues",
-                "source": "https://github.com/sensiolabs/minify-bundle/tree/v1.2.0"
+                "source": "https://github.com/bakslashHQ/minify-bundle/tree/feat/html-support"
             },
-            "time": "2025-08-19T18:45:10+00:00"
+            "time": "2026-05-20T19:18:46+00:00"
         },
         {
             "name": "symfony/asset",
@@ -9835,9 +9838,17 @@
             "time": "2026-02-23T13:21:35+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "sensiolabs/minify-bundle",
+            "version": "dev-feat/html-support",
+            "alias": "1.3.0",
+            "alias_normalized": "1.3.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "sensiolabs/minify-bundle": 20,
         "symfonycasts/tailwind-bundle": 20
     },
     "prefer-stable": true,

--- a/config/reference.php
+++ b/config/reference.php
@@ -1289,6 +1289,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         local_binary?: scalar|Param|null, // Path to the local binary (use "auto" for automatic detection) // Default: false
  *         download_binary?: bool|Param, // Download the binary from GitHub (defaults to "true" in debug mode) // Default: "%kernel.debug%"
  *         download_directory?: scalar|Param|null, // Directory to store the downloaded binary // Default: "%kernel.project_dir%/var/minify"
+ *         version?: scalar|Param|null, // Minify version to download (null for latest) // Default: null
  *     },
  * }
  * @psalm-type ConfigType = array{

--- a/src/Shared/Infrastructure/StaticSiteGeneration/FilesystemStaticPageDumper.php
+++ b/src/Shared/Infrastructure/StaticSiteGeneration/FilesystemStaticPageDumper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shared\Infrastructure\StaticSiteGeneration;
 
 use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+use Sensiolabs\MinifyBundle\Minifier\Options\HtmlOptions;
 use Symfony\Component\Filesystem\Filesystem;
 
 final readonly class FilesystemStaticPageDumper implements StaticPageDumperInterface
@@ -33,9 +34,13 @@ final readonly class FilesystemStaticPageDumper implements StaticPageDumperInter
             $format === 'xml' || str_ends_with($fileName, '.xml') => 'xml',
             default => null,
         };
+        $options = match ($format) {
+            'html' => new HtmlOptions(keepDocumentTags: true),
+            default => null,
+        };
 
         if ($minifyType) {
-            $content = $this->minify->minify($content, $minifyType); // @phpstan-ignore argument.type (the underlying binary supports html/xml)
+            $content = $this->minify->minify($content, $minifyType, $options); // @phpstan-ignore argument.type (the underlying binary supports html/xml), arguments.count
         }
 
         $this->filesystem->dumpFile(\sprintf('%s/%s', $this->outputDir, $fileName), $content);

--- a/templates/pages/blog/article.html.twig
+++ b/templates/pages/blog/article.html.twig
@@ -9,6 +9,7 @@
     <meta property="og:title" content="{{ article.title }}">
     <meta property="og:description" content="{{ article.description }}">
     <meta property="og:image" content="{{ absolute_url('/open-graph/article/' ~ article.id ~ '.jpg') }}">
+    <meta property="og:image:type" content="image/jpeg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="{{ article.title }}">

--- a/templates/pages/blog/index.html.twig
+++ b/templates/pages/blog/index.html.twig
@@ -8,6 +8,9 @@
     <meta property="og:title" content="{{ 'blog.seo.title'|trans|raw }}">
     <meta property="og:description" content="{{ 'blog.seo.description'|trans|raw }}">
     <meta property="og:image" content="{{ absolute_url(asset('images/og.png')) }}">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="{{ 'blog.seo.title'|trans|raw }}">
     <link rel="alternate" type="application/atom+xml" title="baksla.sh Blog" href="{{ url('app_blog_feed') }}">
 {% endblock %}

--- a/templates/pages/team/index.html.twig
+++ b/templates/pages/team/index.html.twig
@@ -8,6 +8,9 @@
     <meta property="og:title" content="{{ 'team.seo.title'|trans|raw }}">
     <meta property="og:description" content="{{ 'team.seo.description'|trans|raw }}">
     <meta property="og:image" content="{{ absolute_url(asset('images/og.png')) }}">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="{{ 'team.seo.title'|trans|raw }}">
 {% endblock %}
 

--- a/templates/pages/website/home.html.twig
+++ b/templates/pages/website/home.html.twig
@@ -8,6 +8,9 @@
     <meta property="og:title" content="{{ 'home.seo.title'|trans|raw }}">
     <meta property="og:description" content="{{ 'home.seo.description'|trans|raw }}">
     <meta property="og:image" content="{{ absolute_url(asset('images/og.png')) }}">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="{{ 'home.seo.title'|trans|raw }}">
 
     <script type="application/ld+json">

--- a/templates/pages/website/legal_notices.html.twig
+++ b/templates/pages/website/legal_notices.html.twig
@@ -10,6 +10,9 @@
     <meta property="og:title" content="{{ 'legal_notices.seo.title'|trans|raw }}">
     <meta property="og:description" content="{{ 'legal_notices.seo.description'|trans|raw }}">
     <meta property="og:image" content="{{ absolute_url(asset('images/og.png')) }}">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta property="og:image:alt" content="{{ 'legal_notices.seo.title'|trans|raw }}">
 {% endblock %}
 


### PR DESCRIPTION
Related to our LinkedIn post preview issue... The `og:image` can't be displayed because of missing `<head>` tags.

Opened https://github.com/sensiolabs/minify-bundle/pull/41.
