### PR TITLE
Minor visual fixes

### DIFF
--- a/templates/components/Home/Kpi.html.twig
+++ b/templates/components/Home/Kpi.html.twig
@@ -38,10 +38,6 @@
                     <div class="mt-4 text-terminal-mute text-base">
                         {{ 'home.kpi.done'|trans }}.
                     </div>
-                    <div class="mt-3 flex items-center gap-x-3.5 gap-y-1">
-                        <span class="text-terminal-prompt">$</span>
-                        <span class="inline-block w-2 h-5 sm:w-2.5 sm:h-6 bg-paper align-text-bottom animate-blink"></span>
-                    </div>
                 </div>
             </div>
         </div>

--- a/templates/components/Home/OpenSourceOverview.html.twig
+++ b/templates/components/Home/OpenSourceOverview.html.twig
@@ -85,14 +85,14 @@
                             <span class="text-sm sm:text-base text-ink-soft leading-snug">
                                 {{ 'home.oss.line.on'|trans }} <span class="text-ink font-medium">{{ project.label }}</span>
                             </span>
-                            <span class="ml-auto font-mono text-xs text-muted opacity-50 group-hover:opacity-100 transition-opacity">
+                            <span class="ml-auto font-mono text-xs text-muted">
                                 {{ project.reviews }}r · {{ project.prs }}p
                             </span>
                         </a>
                     </li>
                 {% endfor %}
             </ul>
-            <p aria-hidden="true" class="mt-4 m-0 font-mono text-xs text-muted text-right opacity-50">
+            <p aria-hidden="true" class="mt-4 m-0 font-mono text-xs text-right text-muted">
                 * <span class="text-ink-soft">r:</span> {{ 'home.oss.stats.reviews'|trans }} · <span class="text-ink-soft">p:</span> {{ 'home.oss.stats.prs'|trans }}
             </p>
         </div>

--- a/templates/components/Home/Products.html.twig
+++ b/templates/components/Home/Products.html.twig
@@ -61,23 +61,23 @@
                             <span class="opacity-60">[{{ ('home.products.product.tag.' ~ service.kind)|trans }}]</span>
                         </div>
 
-                        <div class="p-8 sm:p-10 lg:p-12">
-                            <div class="font-mono text-xs uppercase tracking-widest text-accent mb-3">
+                        <div class="p-4 sm:p-10 lg:p-12">
+                            <div class="font-mono text-xs uppercase tracking-widest text-accent mt-2 sm:mt-0 mb-3">
                                 {{ ('home.products.product.tag.' ~ service.kind)|trans }}
                             </div>
                             <h3 class="font-sans font-medium text-2xl sm:text-3xl lg:text-4xl m-0 leading-tight">
                                 {{- ('home.products.service.' ~ service.slug ~ '.title')|trans -}}
                             </h3>
-                            <p class="mt-6 max-w-xl text-sm sm:text-base leading-relaxed text-ink-soft">
+                            <p class="sm:mt-4 mt-6 max-w-xl text-sm sm:text-base leading-relaxed text-ink-soft">
                                 {{- ('home.products.service.' ~ service.slug ~ '.summary')|trans -}}
                             </p>
                             {% if service.slug == 'architecture' %}
-                                <p class="mt-4 max-w-xl text-sm sm:text-base leading-relaxed text-ink-soft">
+                                <p class="sm:mt-2 mt-4 max-w-xl text-sm sm:text-base leading-relaxed text-ink-soft">
                                     {{- ('home.products.service.architecture.detail')|trans -}}
                                 </p>
                                 <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
                                     {% for case in ['new', 'existing'] %}
-                                        <div class="border border-ink/15 rounded-lg p-5">
+                                        <div class="border border-ink/15 rounded-lg p-3 sm:p-5">
                                             <div class="font-mono text-xs uppercase tracking-widest text-accent mb-2">
                                                 {{- ('home.products.service.architecture.detail_' ~ case ~ '_label')|trans -}}
                                             </div>


### PR DESCRIPTION
- **Reduce paddings in `Products` component for mobile version**

https://github.com/user-attachments/assets/f33725b1-d64b-4ccf-8cc0-25fa212eee48



- **Improve accessibility by increasing contrast for "...r ...pr" text**

| Before | After |
|--------|--------|
| <img width="444" height="734" alt="Capture d’écran 2026-06-04 à 07 25 56" src="https://github.com/user-attachments/assets/d87388db-c7ad-4701-8fd4-8c77bb09fcb9" /> | <img width="446" height="742" alt="Capture d’écran 2026-06-04 à 07 26 01" src="https://github.com/user-attachments/assets/0edbe863-e614-4b9d-a50e-e78e8fa7568e" /> | 



- **Do not re-display prompt after triggering the Kpi, since its not responding to anything**

https://github.com/user-attachments/assets/03651279-bbde-4b2d-95f8-e27d1cc27c86

