### PR TITLE
Add PHPStan Symfony UX rules and update component classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
     ],
     "require-dev": {
         "kocal/biome-js-bundle": "^2.1.2",
+        "kocal/phpstan-symfony-ux": "^1.3",
         "phpstan/phpstan": "^2.1.55",
         "phpstan/phpstan-symfony": "^2.0.18",
         "phpunit/phpunit": "^11.5.55",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d019eed4f955c54883f945d5d1f5852",
+    "content-hash": "87c73b7a8184b3463e2324d4ccacc169",
     "packages": [
         {
             "name": "composer/semver",
@@ -7132,6 +7132,60 @@
                 "source": "https://github.com/Kocal/BiomeJsBundle/tree/v2.1.2"
             },
             "time": "2025-12-02T13:43:17+00:00"
+        },
+        {
+            "name": "kocal/phpstan-symfony-ux",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kocal/phpstan-symfony-ux.git",
+                "reference": "1541d68137e23c89872e43153b09d6c82e15bef4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kocal/phpstan-symfony-ux/zipball/1541d68137e23c89872e43153b09d6c82e15bef4",
+                "reference": "1541d68137e23c89872e43153b09d6c82e15bef4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpstan": "^2.1.13"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.1",
+                "symfony/ux-live-component": "^2.0",
+                "symfony/ux-twig-component": "^2.0",
+                "symplify/easy-coding-standard": "^13.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kocal\\PHPStanSymfonyUX\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hugo Alliaume",
+                    "email": "hugo@alliau.me"
+                }
+            ],
+            "description": "PHPStan rules for Symfony UX",
+            "support": {
+                "issues": "https://github.com/Kocal/phpstan-symfony-ux/issues",
+                "source": "https://github.com/Kocal/phpstan-symfony-ux/tree/v1.3.0"
+            },
+            "time": "2026-02-25T20:48:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,7 +1,19 @@
 includes:
+    - vendor/kocal/phpstan-symfony-ux/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - tools/phpstan/symfony-configuration.php
     - phpstan-baseline.neon
+
+rules:
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ClassMustBeFinalRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ClassNameMustNotEndWithComponentRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenAttributesPropertyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenClassPropertyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\ForbiddenReadonlyRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\MethodsVisibilityRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PostMountMethodSignatureRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PreMountMethodSignatureRule
+    - Kocal\PHPStanSymfonyUX\Rules\TwigComponent\PublicPropertiesMustBeCamelCaseRule
 
 parameters:
     level: max

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector;
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 
 return RectorConfig::configure()
     ->withParallel()
@@ -31,5 +33,11 @@ return RectorConfig::configure()
         __DIR__ . '/config/reference.php',
         MakeInheritedMethodVisibilitySameAsParentRector::class,
         NewlineAfterStatementRector::class,
+        ReadOnlyClassRector::class => [
+            __DIR__ . '/src/*/Infrastructure/Rendering/Components/*.php',
+        ],
+        ReadOnlyPropertyRector::class => [
+            __DIR__ . '/src/*/Infrastructure/Rendering/Components/*.php',
+        ],
     ])
 ;

--- a/src/Home/Infrastructure/Rendering/Components/BlogOverview.php
+++ b/src/Home/Infrastructure/Rendering/Components/BlogOverview.php
@@ -9,12 +9,12 @@ use App\Blog\Domain\Repository\ArticlePreviewRepository;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(name: 'Home:BlogOverview', template: 'components/Home/BlogOverview.html.twig')]
-final readonly class BlogOverview
+final class BlogOverview
 {
     private const int OTHERS_LIMIT = 2;
 
     public function __construct(
-        private ArticlePreviewRepository $articlePreviewRepository,
+        private readonly ArticlePreviewRepository $articlePreviewRepository,
     ) {
     }
 

--- a/src/Home/Infrastructure/Rendering/Components/Kpi.php
+++ b/src/Home/Infrastructure/Rendering/Components/Kpi.php
@@ -9,10 +9,10 @@ use App\Team\Domain\Repository\MemberRepository;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(name: 'Home:Kpi', template: 'components/Home/Kpi.html.twig')]
-final readonly class Kpi
+final class Kpi
 {
     public function __construct(
-        private MemberRepository $memberRepository,
+        private readonly MemberRepository $memberRepository,
     ) {
     }
 

--- a/src/Home/Infrastructure/Rendering/Components/OpenSourceOverview.php
+++ b/src/Home/Infrastructure/Rendering/Components/OpenSourceOverview.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(name: 'Home:OpenSourceOverview', template: 'components/Home/OpenSourceOverview.html.twig')]
-final readonly class OpenSourceOverview
+final class OpenSourceOverview
 {
     public const int SINCE_YEAR = 2010;
 

--- a/src/Website/Infrastructure/Rendering/Components/CommandPalette.php
+++ b/src/Website/Infrastructure/Rendering/Components/CommandPalette.php
@@ -9,10 +9,10 @@ use App\Blog\Domain\Repository\ArticlePreviewRepository;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
 #[AsTwigComponent(name: 'website:CommandPalette', template: 'components/website/CommandPalette.html.twig')]
-final readonly class CommandPalette
+final class CommandPalette
 {
     public function __construct(
-        private ArticlePreviewRepository $articlePreviewRepository,
+        private readonly ArticlePreviewRepository $articlePreviewRepository,
     ) {
     }
 


### PR DESCRIPTION
Mini auto-promo (https://github.com/Kocal/phpstan-symfony-ux), mais je considère ces règles des must-haves en travaillant avec les composants Twig (spécialement avec la nuance de la classe `readonly`).

Je n'ai pas inclus les règles sur les LiveComponent (on n'en a pas), ni la règle `ExposePublicPropsMustBeFalseRule`
