### PR TITLE
Centralize OSS projects for data fetching/displaying, split Encore & fix Tactician logger

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Team\Infrastructure\Repository\InMemoryMemberRepository;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
@@ -29,8 +28,4 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             sprintf('%s/src/DependencyInjection/', dirname(__DIR__)),
             sprintf('%s/src/Kernel.php', dirname(__DIR__)),
         ]);
-
-    $services
-        ->get(InMemoryMemberRepository::class)
-        ->factory([InMemoryMemberRepository::class, 'createDefault']);
 };

--- a/data/open-source-stats.json
+++ b/data/open-source-stats.json
@@ -32,8 +32,8 @@
         "pullRequests": 33
     },
     "tactician": {
-        "reviews": 11,
-        "pullRequests": 12
+        "reviews": 12,
+        "pullRequests": 13
     },
     "biome-js-bundle": {
         "reviews": 3,

--- a/data/open-source-stats.json
+++ b/data/open-source-stats.json
@@ -4,12 +4,16 @@
         "pullRequests": 1180
     },
     "symfony-ux": {
-        "reviews": 601,
-        "pullRequests": 544
+        "reviews": 609,
+        "pullRequests": 547
     },
     "symfony-reprise": {
         "reviews": 3,
-        "pullRequests": 60
+        "pullRequests": 62
+    },
+    "webpack-encore": {
+        "reviews": 80,
+        "pullRequests": 149
     },
     "api-platform": {
         "reviews": 38,

--- a/src/Home/Infrastructure/Rendering/Components/OpenSourceOverview.php
+++ b/src/Home/Infrastructure/Rendering/Components/OpenSourceOverview.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Home\Infrastructure\Rendering\Components;
 
 use App\OpenSource\Domain\Model\OpenSourceStats;
+use App\OpenSource\Domain\Repository\ProjectRepository;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
@@ -13,65 +14,10 @@ final class OpenSourceOverview
 {
     public const int SINCE_YEAR = 2010;
 
-    /**
-     * @var array<string, array{label: string, short: string, url: string}>
-     */
-    private const array META = [
-        'symfony' => [
-            'label' => 'Symfony',
-            'short' => 'symfony/symfony',
-            'url' => 'https://github.com/symfony/symfony',
-        ],
-        'symfony-ux' => [
-            'label' => 'Symfony UX',
-            'short' => 'symfony/ux',
-            'url' => 'https://github.com/symfony/ux',
-        ],
-        'symfony-reprise' => [
-            'label' => 'Reprise',
-            'short' => 'symfony/reprise',
-            'url' => 'https://github.com/symfony/reprise',
-        ],
-        'api-platform' => [
-            'label' => 'API Platform',
-            'short' => 'api-platform/core',
-            'url' => 'https://github.com/api-platform/core',
-        ],
-        'sylius' => [
-            'label' => 'Sylius',
-            'short' => 'Sylius/Sylius',
-            'url' => 'https://github.com/Sylius/Sylius',
-        ],
-        'lexik-jwt' => [
-            'label' => 'LexikJWTAuthBundle',
-            'short' => 'lexik/jwt-auth',
-            'url' => 'https://github.com/lexik/LexikJWTAuthenticationBundle',
-        ],
-        'oauth2-server-bundle' => [
-            'label' => 'OAuth2 Server Bundle',
-            'short' => 'league/oauth2-server-bundle',
-            'url' => 'https://github.com/thephpleague/oauth2-server-bundle',
-        ],
-        'tactician' => [
-            'label' => 'Tactician',
-            'short' => 'thephpleague/tactician',
-            'url' => 'https://github.com/thephpleague/tactician',
-        ],
-        'biome-js-bundle' => [
-            'label' => 'BiomeJsBundle',
-            'short' => 'Kocal/BiomeJsBundle',
-            'url' => 'https://github.com/Kocal/BiomeJsBundle',
-        ],
-        'phpstan-symfony-ux' => [
-            'label' => 'PHPStan Symfony UX',
-            'short' => 'Kocal/phpstan-symfony-ux',
-            'url' => 'https://github.com/Kocal/phpstan-symfony-ux',
-        ],
-    ];
-
     private OpenSourceStats $stats;
 
     public function __construct(
+        private readonly ProjectRepository $projectRepository,
         #[Autowire(param: 'app.open_source_stats_file')]
         string $statsFile,
     ) {
@@ -79,22 +25,20 @@ final class OpenSourceOverview
     }
 
     /**
-     * @return list<array{id: string, label: string, short: string, url: string, reviews: int, prs: int, sum: int}>
+     * @return list<array{label: string, url: string, reviews: int, prs: int, sum: int}>
      */
     public function getProjects(): array
     {
         $projects = [];
-        foreach (self::META as $id => $meta) {
-            if (!$this->stats->hasProject($id)) {
+        foreach ($this->projectRepository->findAll() as $project) {
+            if (!$this->stats->hasProject($project->id)) {
                 continue;
             }
-            $reviews = $this->stats->reviewsFor($id);
-            $prs = $this->stats->pullRequestsFor($id);
+            $reviews = $this->stats->reviewsFor($project->id);
+            $prs = $this->stats->pullRequestsFor($project->id);
             $projects[] = [
-                'id' => $id,
-                'label' => $meta['label'],
-                'short' => $meta['short'],
-                'url' => $meta['url'],
+                'label' => $project->label,
+                'url' => $project->getUrl(),
                 'reviews' => $reviews,
                 'prs' => $prs,
                 'sum' => $reviews + $prs,

--- a/src/OpenSource/Domain/Model/OpenSourceStats.php
+++ b/src/OpenSource/Domain/Model/OpenSourceStats.php
@@ -36,19 +36,19 @@ final readonly class OpenSourceStats
         return new self($data);
     }
 
-    public function hasProject(string $project): bool
+    public function hasProject(ProjectId $project): bool
     {
-        return isset($this->stats[$project]);
+        return isset($this->stats[$project->value]);
     }
 
-    public function reviewsFor(string $project): int
+    public function reviewsFor(ProjectId $project): int
     {
-        return $this->stats[$project]['reviews'] ?? 0;
+        return $this->stats[$project->value]['reviews'] ?? 0;
     }
 
-    public function pullRequestsFor(string $project): int
+    public function pullRequestsFor(ProjectId $project): int
     {
-        return $this->stats[$project]['pullRequests'] ?? 0;
+        return $this->stats[$project->value]['pullRequests'] ?? 0;
     }
 
     public function getTotalReviews(): int

--- a/src/OpenSource/Domain/Model/Project.php
+++ b/src/OpenSource/Domain/Model/Project.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenSource\Domain\Model;
+
+final readonly class Project
+{
+    /**
+     * @param non-empty-string                 $label
+     * @param non-empty-list<non-empty-string> $repositories GitHub "owner/name" slugs; the first one is the project's canonical repository
+     */
+    public function __construct(
+        public ProjectId $id,
+        public string $label,
+        public array $repositories,
+    ) {
+    }
+
+    public function getUrl(): string
+    {
+        return \sprintf('https://github.com/%s', $this->repositories[0]);
+    }
+}

--- a/src/OpenSource/Domain/Model/ProjectId.php
+++ b/src/OpenSource/Domain/Model/ProjectId.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenSource\Domain\Model;
+
+enum ProjectId: string
+{
+    case ApiPlatform = 'api-platform';
+    case BiomeJsBundle = 'biome-js-bundle';
+    case LexikJwt = 'lexik-jwt';
+    case OAuth2ServerBundle = 'oauth2-server-bundle';
+    case PhpstanSymfonyUx = 'phpstan-symfony-ux';
+    case Symfony = 'symfony';
+    case SymfonyReprise = 'symfony-reprise';
+    case SymfonyUx = 'symfony-ux';
+    case Sylius = 'sylius';
+    case Tactician = 'tactician';
+    case WebpackEncore = 'webpack-encore';
+}

--- a/src/OpenSource/Domain/Repository/ProjectRepository.php
+++ b/src/OpenSource/Domain/Repository/ProjectRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenSource\Domain\Repository;
+
+use App\OpenSource\Domain\Model\Project;
+use App\OpenSource\Domain\Model\ProjectId;
+
+interface ProjectRepository
+{
+    /**
+     * @return array<value-of<ProjectId>, Project>
+     */
+    public function findAll(): array;
+}

--- a/src/OpenSource/Infrastructure/Command/RefreshOpenSourceStatsCommand.php
+++ b/src/OpenSource/Infrastructure/Command/RefreshOpenSourceStatsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\OpenSource\Infrastructure\Command;
 
 use App\OpenSource\Domain\Model\OpenSourceStats;
+use App\OpenSource\Domain\Repository\ProjectRepository;
 use App\OpenSource\Infrastructure\GitHub\GitHubClient;
 use App\Team\Domain\Model\Member;
 use App\Team\Domain\Repository\MemberRepository;
@@ -20,49 +21,9 @@ use Symfony\Component\Filesystem\Filesystem;
 )]
 final readonly class RefreshOpenSourceStatsCommand
 {
-    /**
-     * @var array<string, list<string>>
-     */
-    public const array REPOS = [
-        'symfony' => [
-            'symfony/symfony',
-            'symfony/symfony-docs',
-            'symfony/demo',
-            'symfony/polyfill',
-            'symfony/recipes',
-            'symfony/recipes-contrib',
-            'symfony/maker-bundle',
-            'symfony/monolog-bundle',
-            'symfony/mercure',
-            'symfony/mercure-bundle',
-            'symfony/panther',
-            'symfony/ai',
-        ],
-        'symfony-ux' => [
-            'symfony/ux',
-            'symfony/ux.symfony.com',
-        ],
-        'symfony-reprise' => ['symfony/reprise'],
-        'api-platform' => ['api-platform/core'],
-        'sylius' => [
-            'Sylius/Sylius',
-            'Sylius/Stack',
-            'Sylius/SyliusGridBundle',
-            'Sylius/SyliusResourceBundle',
-        ],
-        'lexik-jwt' => ['lexik/LexikJWTAuthenticationBundle'],
-        'oauth2-server-bundle' => ['thephpleague/oauth2-server-bundle'],
-        'tactician' => [
-            'thephpleague/tactician',
-            'thephpleague/tactician-bundle',
-            'thephpleague/tactian-logger',
-        ],
-        'biome-js-bundle' => ['Kocal/BiomeJsBundle'],
-        'phpstan-symfony-ux' => ['Kocal/phpstan-symfony-ux'],
-    ];
-
     public function __construct(
         private GitHubClient $githubClient,
+        private ProjectRepository $projectRepository,
         private MemberRepository $memberRepository,
         private Filesystem $filesystem,
         #[Autowire(param: 'app.open_source_stats_file')]
@@ -72,27 +33,29 @@ final readonly class RefreshOpenSourceStatsCommand
 
     public function __invoke(SymfonyStyle $io): int
     {
+        $projects = $this->projectRepository->findAll();
+
         $counts = $this->githubClient->countPullRequests(
-            array_merge(...array_values(self::REPOS)),
+            array_merge(...array_column($projects, 'repositories')),
             array_values(array_map(fn (Member $member): string => $member->github, $this->memberRepository->findAll())),
         );
 
         $previous = OpenSourceStats::fromJsonFile($this->statsFile);
 
         $stats = [];
-        foreach (self::REPOS as $project => $repos) {
+        foreach ($projects as $project) {
             $reviews = 0;
             $pullRequests = 0;
-            foreach ($repos as $repo) {
+            foreach ($project->repositories as $repo) {
                 $reviews += $counts[$repo]->reviewed;
                 $pullRequests += $counts[$repo]->authored;
             }
 
             // GitHub's search.issueCount is an estimate for large result sets and drifts run-to-run;
             // ratchet upward so the published numbers never regress.
-            $stats[$project] = [
-                'reviews' => max($previous->reviewsFor($project), $reviews),
-                'pullRequests' => max($previous->pullRequestsFor($project), $pullRequests),
+            $stats[$project->id->value] = [
+                'reviews' => max($previous->reviewsFor($project->id), $reviews),
+                'pullRequests' => max($previous->pullRequestsFor($project->id), $pullRequests),
             ];
         }
 

--- a/src/OpenSource/Infrastructure/Repository/InMemoryProjectRepository.php
+++ b/src/OpenSource/Infrastructure/Repository/InMemoryProjectRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\OpenSource\Infrastructure\Repository;
+
+use App\OpenSource\Domain\Model\Project;
+use App\OpenSource\Domain\Model\ProjectId;
+use App\OpenSource\Domain\Repository\ProjectRepository;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(constructor: 'createDefault')]
+final readonly class InMemoryProjectRepository implements ProjectRepository
+{
+    /**
+     * @var array<value-of<ProjectId>, Project>
+     */
+    private array $projects;
+
+    /**
+     * @param list<Project> $projects
+     */
+    public function __construct(array $projects = [])
+    {
+        $indexedProjects = [];
+
+        foreach ($projects as $project) {
+            $indexedProjects[$project->id->value] = $project;
+        }
+
+        $this->projects = $indexedProjects;
+    }
+
+    public static function createDefault(): self
+    {
+        return new self([
+            new Project(ProjectId::Symfony, 'Symfony', [
+                'symfony/symfony',
+                'symfony/symfony-docs',
+                'symfony/demo',
+                'symfony/polyfill',
+                'symfony/recipes',
+                'symfony/recipes-contrib',
+                'symfony/maker-bundle',
+                'symfony/monolog-bundle',
+                'symfony/mercure',
+                'symfony/mercure-bundle',
+                'symfony/panther',
+                'symfony/ai',
+            ]),
+            new Project(ProjectId::SymfonyUx, 'Symfony UX', [
+                'symfony/ux',
+                'symfony/ux.symfony.com',
+            ]),
+            new Project(ProjectId::SymfonyReprise, 'Reprise', [
+                'symfony/reprise',
+            ]),
+            new Project(ProjectId::WebpackEncore, 'Webpack Encore', [
+                'symfony/webpack-encore',
+                'symfony/webpack-encore-bundle',
+            ]),
+            new Project(ProjectId::ApiPlatform, 'API Platform', [
+                'api-platform/core',
+            ]),
+            new Project(ProjectId::Sylius, 'Sylius', [
+                'Sylius/Sylius',
+                'Sylius/Stack',
+                'Sylius/SyliusGridBundle',
+                'Sylius/SyliusResourceBundle',
+            ]),
+            new Project(ProjectId::LexikJwt, 'LexikJWTAuthBundle', [
+                'lexik/LexikJWTAuthenticationBundle',
+            ]),
+            new Project(ProjectId::OAuth2ServerBundle, 'OAuth2 Server Bundle', [
+                'thephpleague/oauth2-server-bundle',
+            ]),
+            new Project(ProjectId::Tactician, 'Tactician', [
+                'thephpleague/tactician',
+                'thephpleague/tactician-bundle',
+                'thephpleague/tactian-logger',
+            ]),
+            new Project(ProjectId::BiomeJsBundle, 'BiomeJsBundle', [
+                'Kocal/BiomeJsBundle',
+            ]),
+            new Project(ProjectId::PhpstanSymfonyUx, 'PHPStan Symfony UX', [
+                'Kocal/phpstan-symfony-ux',
+            ]),
+        ]);
+    }
+
+    public function findAll(): array
+    {
+        return $this->projects;
+    }
+}

--- a/src/OpenSource/Infrastructure/Repository/InMemoryProjectRepository.php
+++ b/src/OpenSource/Infrastructure/Repository/InMemoryProjectRepository.php
@@ -77,7 +77,7 @@ final readonly class InMemoryProjectRepository implements ProjectRepository
             new Project(ProjectId::Tactician, 'Tactician', [
                 'thephpleague/tactician',
                 'thephpleague/tactician-bundle',
-                'thephpleague/tactian-logger',
+                'thephpleague/tactician-logger',
             ]),
             new Project(ProjectId::BiomeJsBundle, 'BiomeJsBundle', [
                 'Kocal/BiomeJsBundle',

--- a/src/Team/Infrastructure/Repository/InMemoryMemberRepository.php
+++ b/src/Team/Infrastructure/Repository/InMemoryMemberRepository.php
@@ -10,7 +10,9 @@ use App\Team\Domain\Model\Member;
 use App\Team\Domain\Model\MemberId;
 use App\Team\Domain\Model\SocialNetwork;
 use App\Team\Domain\Repository\MemberRepository;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 
+#[Autoconfigure(constructor: 'createDefault')]
 final readonly class InMemoryMemberRepository implements MemberRepository
 {
     /**

--- a/templates/components/Home/OpenSourceOverview.html.twig
+++ b/templates/components/Home/OpenSourceOverview.html.twig
@@ -51,7 +51,7 @@
                     {% for project in this.projects %}
                         <div
                             style="width: {{ (project.sum / this.total * 100)|number_format(4, '.', '') }}%;"
-                            class="group relative h-full bg-accent transition-opacity duration-200 hover:opacity-100 {{ barOpacityClasses[loop.index0] ?? 'opacity-40' }} {% if loop.first %}rounded-l-full{% endif %} {% if loop.last %}rounded-r-full{% endif %} {% if not loop.last %}border-r-2 border-paper{% endif %}"
+                            class="group relative h-full bg-accent transition-opacity duration-200 hover:opacity-100 {{ barOpacityClasses[loop.index0] ?? barOpacityClasses|last }} {% if loop.first %}rounded-l-full{% endif %} {% if loop.last %}rounded-r-full{% endif %} {% if not loop.last %}border-r-2 border-paper{% endif %}"
                         >
                             <span
                                 aria-hidden="true"

--- a/tests/Builder/ProjectBuilder.php
+++ b/tests/Builder/ProjectBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Builder;
+
+use App\OpenSource\Domain\Model\Project;
+use App\OpenSource\Domain\Model\ProjectId;
+use Faker\Factory;
+
+final class ProjectBuilder
+{
+    private ProjectId|NotSet $id = NotSet::VALUE;
+
+    /**
+     * @var non-empty-list<non-empty-string>|NotSet
+     */
+    private array|NotSet $repositories = NotSet::VALUE;
+
+    public function withId(ProjectId $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $repository
+     * @param non-empty-string ...$otherRepositories
+     */
+    public function withRepositories(string $repository, string ...$otherRepositories): self
+    {
+        $this->repositories = [$repository, ...array_values($otherRepositories)];
+
+        return $this;
+    }
+
+    public function build(): Project
+    {
+        $faker = Factory::create();
+
+        /** @var ProjectId $id */
+        $id = $this->id !== NotSet::VALUE ? $this->id : $faker->randomElement(ProjectId::cases());
+
+        /** @var non-empty-string $label */
+        $label = $faker->words(2, true);
+
+        /** @var non-empty-string $repository */
+        $repository = \sprintf('%s/%s', $faker->userName(), $faker->slug(1));
+
+        return new Project(
+            id: $id,
+            label: $label,
+            repositories: $this->repositories !== NotSet::VALUE ? $this->repositories : [$repository],
+        );
+    }
+}

--- a/tests/Func/RefreshOpenSourceStatsTest.php
+++ b/tests/Func/RefreshOpenSourceStatsTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Func;
 
-use App\OpenSource\Infrastructure\Command\RefreshOpenSourceStatsCommand;
+use App\OpenSource\Domain\Model\ProjectId;
+use App\OpenSource\Domain\Repository\ProjectRepository;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -49,11 +50,16 @@ final class RefreshOpenSourceStatsTest extends KernelTestCase
         /** @var array<string, array{reviews: int, pullRequests: int}> $stats */
         $stats = json_decode((string) file_get_contents($this->statsFile), true, flags: \JSON_THROW_ON_ERROR);
 
-        $this->assertSame(\count(RefreshOpenSourceStatsCommand::REPOS['symfony']) * self::FAKE_ISSUE_COUNT, $stats['symfony']['reviews']);
-        $this->assertSame(\count(RefreshOpenSourceStatsCommand::REPOS['symfony']) * self::FAKE_ISSUE_COUNT, $stats['symfony']['pullRequests']);
+        $projects = self::getContainer()->get(ProjectRepository::class)->findAll();
 
-        $this->assertSame(self::FAKE_ISSUE_COUNT, $stats['api-platform']['reviews']);
-        $this->assertSame(self::FAKE_ISSUE_COUNT, $stats['api-platform']['pullRequests']);
+        foreach ($projects as $id => $project) {
+            $expected = \count($project->repositories) * self::FAKE_ISSUE_COUNT;
+
+            $this->assertSame($expected, $stats[$id]['reviews']);
+            $this->assertSame($expected, $stats[$id]['pullRequests']);
+        }
+
+        $this->assertCount(\count(ProjectId::cases()), $stats);
     }
 
     private function fakeGithubHttpClient(): HttpClientInterface

--- a/tests/Unit/OpenSource/Domain/Model/ProjectTest.php
+++ b/tests/Unit/OpenSource/Domain/Model/ProjectTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\OpenSource\Domain\Model;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProjectTest extends TestCase
+{
+    public function testUrlPointsToTheCanonicalRepository(): void
+    {
+        $project = aProject()->withRepositories('symfony/webpack-encore', 'symfony/webpack-encore-bundle')->build();
+
+        $this->assertSame('https://github.com/symfony/webpack-encore', $project->getUrl());
+    }
+}

--- a/tests/Unit/OpenSource/Infrastructure/Repository/InMemoryProjectRepositoryTest.php
+++ b/tests/Unit/OpenSource/Infrastructure/Repository/InMemoryProjectRepositoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\OpenSource\Infrastructure\Repository;
+
+use App\OpenSource\Domain\Model\ProjectId;
+use App\OpenSource\Infrastructure\Repository\InMemoryProjectRepository;
+use PHPUnit\Framework\TestCase;
+
+final class InMemoryProjectRepositoryTest extends TestCase
+{
+    public function testFindAll(): void
+    {
+        $repository = new InMemoryProjectRepository([aProject()->build()]);
+
+        $this->assertCount(1, $repository->findAll());
+    }
+
+    public function testFindAllReturnsProjectsIndexedById(): void
+    {
+        $repository = new InMemoryProjectRepository([
+            aProject()->withId(ProjectId::Symfony)->build(),
+            aProject()->withId(ProjectId::WebpackEncore)->build(),
+        ]);
+
+        foreach ($repository->findAll() as $id => $project) {
+            $this->assertSame($id, $project->id->value);
+        }
+    }
+
+    public function testCreateDefaultCoversEveryProjectId(): void
+    {
+        $projects = InMemoryProjectRepository::createDefault()->findAll();
+
+        $this->assertEqualsCanonicalizing(
+            array_column(ProjectId::cases(), 'value'),
+            array_keys($projects),
+            'Every ProjectId must have an entry in the default catalog, otherwise it never gets any stats.',
+        );
+    }
+
+    public function testCreateDefaultListsEachRepositoryOnce(): void
+    {
+        $repositories = array_merge(...array_column(InMemoryProjectRepository::createDefault()->findAll(), 'repositories'));
+
+        $duplicates = array_keys(array_filter(array_count_values($repositories), fn (int $count): bool => $count > 1));
+
+        $this->assertSame([], $duplicates, 'A repository listed under two projects has its contributions counted twice.');
+    }
+}

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Tests\Builder\ArticleBuilder;
 use App\Tests\Builder\MemberBuilder;
+use App\Tests\Builder\ProjectBuilder;
 
 function anArticle(): ArticleBuilder
 {
@@ -13,4 +14,9 @@ function anArticle(): ArticleBuilder
 function aMember(): MemberBuilder
 {
     return new MemberBuilder();
+}
+
+function aProject(): ProjectBuilder
+{
+    return new ProjectBuilder();
 }


### PR DESCRIPTION
C'est la maison qui offre : 
<img width="1368" height="1006" alt="Capture d’écran 2026-08-23 à 16 17 39" src="https://github.com/user-attachments/assets/8a363ed4-1f4a-47e6-bd8c-82bc0182f03d" />


Peut-être que ça vaudrait le coup de cacher les contribs à <25, ou alors ~60 avec un fold...? 