### PR TITLE
Remove partial opacity of crew member's pic blurred background

### DIFF
--- a/templates/components/Team/MemberModal.html.twig
+++ b/templates/components/Team/MemberModal.html.twig
@@ -38,7 +38,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-[18rem_1fr] md:min-h-[24rem]">
                     <div class="relative overflow-hidden h-40 md:h-auto md:min-h-[14rem]">
                         <img
-                            class="absolute inset-0 size-full scale-120 object-cover blur-2xl opacity-70"
+                            class="absolute inset-0 size-full scale-120 object-cover blur-2xl"
                             src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
                             alt=""
                         />


### PR DESCRIPTION
J'ai le feeling que c'est mieux ainsi

<img width="1912" height="1242" alt="Capture d’écran 2026-08-23 à 16 29 33" src="https://github.com/user-attachments/assets/7d981240-770b-428a-b9ef-3e7c9c0a4479" />

<img width="1912" height="1242" alt="Capture d’écran 2026-08-23 à 16 29 39" src="https://github.com/user-attachments/assets/5b51dcd9-ae2d-4cdd-9c0b-ddcedd8533bd" />

<img width="1912" height="1242" alt="Capture d’écran 2026-08-23 à 16 29 46" src="https://github.com/user-attachments/assets/fd660e40-0d8a-457b-9973-0e0f16543973" />
