### PR TITLE
Fix team modal height jump and add scroll fade + keyboard nav

### DIFF
--- a/assets/controllers/member_modal_controller.js
+++ b/assets/controllers/member_modal_controller.js
@@ -1,7 +1,20 @@
 import { Controller } from '@hotwired/stimulus';
 
-const CLOSED_CLASSES = ['opacity-0', 'translate-y-4', 'scale-95'];
-const OPEN_CLASSES = ['opacity-100', 'scale-100'];
+const VISIBLE_CLASSES = ['opacity-100', 'scale-100'];
+
+// Opening and closing lift the modal and scale it down, while moving between members only slides sideways.
+const ENTER_CLASSES = {
+  initial: ['opacity-0', 'scale-95', 'translate-y-4'],
+  prev: ['opacity-0', '-translate-x-8'],
+  next: ['opacity-0', 'translate-x-8'],
+};
+const LEAVE_CLASSES = {
+  initial: ENTER_CLASSES.initial,
+  prev: ENTER_CLASSES.next,
+  next: ENTER_CLASSES.prev,
+};
+const RESET_CLASSES = [...new Set([...VISIBLE_CLASSES, ...Object.values(ENTER_CLASSES).flat()])];
+const LEAVE_DURATION = 150;
 
 /**
  * @property {HTMLElement} modalTarget
@@ -24,7 +37,7 @@ export default class extends Controller {
 
     // Openers live outside the controller element (reviewer rail, comment headers),
     // so Stimulus actions can't reach them, so bind manually here.
-    this.openerHandler = this.open.bind(this);
+    this.openerHandler = () => this.open();
     this.openers = Array.from(document.querySelectorAll(`[data-open-member-modal="${this.memberValue}"]`));
     for (const opener of this.openers) {
       opener.addEventListener('click', this.openerHandler);
@@ -38,17 +51,18 @@ export default class extends Controller {
     }
   }
 
-  open() {
+  open(direction = 'initial') {
+    this.#setState(ENTER_CLASSES[direction]);
     this.element.showModal();
 
     // Force a paint with the initial (closed) state before animating to the open state
     // so the CSS transition actually fires when chaining open() right after close().
-    requestAnimationFrame(() => this.#setOpenState());
+    requestAnimationFrame(() => this.#setState(VISIBLE_CLASSES));
   }
 
   close() {
-    this.#setClosedState();
-    this.timeoutClose = setTimeout(() => this.element.close(), 150);
+    this.#setState(LEAVE_CLASSES.initial);
+    this.timeoutClose = setTimeout(() => this.element.close(), this.#leaveDuration());
   }
 
   onCancel(event) {
@@ -58,34 +72,52 @@ export default class extends Controller {
   }
 
   prev(event) {
-    this.#navigateTo(event, this.prevValue);
+    this.#navigateTo(event, this.prevValue, 'prev');
   }
 
   next(event) {
-    this.#navigateTo(event, this.nextValue);
+    this.#navigateTo(event, this.nextValue, 'next');
   }
 
-  #navigateTo(event, memberId) {
+  onKeydown(event) {
+    if (event.repeat || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      this.prev(event);
+    } else if (event.key === 'ArrowRight') {
+      this.next(event);
+    }
+  }
+
+  #navigateTo(event, memberId, direction) {
     if (!this.element.open || !memberId) {
       return;
     }
 
     event.preventDefault();
     clearTimeout(this.timeoutClose);
-    this.#setClosedState();
-    this.element.close();
+    this.#setState(LEAVE_CLASSES[direction]);
 
     const target = document.querySelector(`dialog[data-member-modal-member-value="${memberId}"]`);
-    this.application.getControllerForElementAndIdentifier(target, 'member-modal')?.open();
+
+    // Only one dialog can be modal at a time, so the outgoing slide has to finish before the next one opens.
+    this.timeoutClose = setTimeout(() => {
+      this.element.close();
+      this.application.getControllerForElementAndIdentifier(target, 'member-modal')?.open(direction);
+    }, this.#leaveDuration());
   }
 
-  #setOpenState() {
-    this.modalTarget.classList.add(...OPEN_CLASSES);
-    this.modalTarget.classList.remove(...CLOSED_CLASSES);
+  // prefers-reduced-motion zeroes the CSS transition, so the wait has to follow it rather than the constant.
+  #leaveDuration() {
+    const transition = parseFloat(getComputedStyle(this.modalTarget).transitionDuration) * 1000;
+
+    return Math.min(transition, LEAVE_DURATION);
   }
 
-  #setClosedState() {
-    this.modalTarget.classList.add(...CLOSED_CLASSES);
-    this.modalTarget.classList.remove(...OPEN_CLASSES);
+  #setState(classes) {
+    this.modalTarget.classList.remove(...RESET_CLASSES);
+    this.modalTarget.classList.add(...classes);
   }
 }

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -71,6 +71,18 @@
   }
 }
 
+@property --scroll-fade-top {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --scroll-fade-bottom {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0px;
+}
+
 @layer utilities {
   .rule-dotted {
     background-image: repeating-linear-gradient(
@@ -88,6 +100,40 @@
     background-size: 1.375rem 1.375rem;
     background-position: 0 0;
     mask-image: radial-gradient(ellipse 60% 60% at 50% 30%, #000 30%, transparent 75%);
+  }
+
+  .scroll-fade {
+    --scroll-fade-size: 1.5rem;
+
+    /* Without a timeline the animation would run at its default 0s duration and freeze the top fade on. */
+    @supports (animation-timeline: scroll()) {
+      mask-image: linear-gradient(
+        to bottom,
+        transparent 0,
+        #000 var(--scroll-fade-top),
+        #000 calc(100% - var(--scroll-fade-bottom)),
+        transparent 100%
+      );
+      animation:
+        scroll-fade-top linear both,
+        scroll-fade-bottom linear both;
+      animation-timeline: scroll(self block);
+      animation-range:
+        0 var(--scroll-fade-size),
+        calc(100% - var(--scroll-fade-size)) 100%;
+    }
+  }
+
+  @keyframes scroll-fade-top {
+    to {
+      --scroll-fade-top: var(--scroll-fade-size);
+    }
+  }
+
+  @keyframes scroll-fade-bottom {
+    from {
+      --scroll-fade-bottom: var(--scroll-fade-size);
+    }
   }
 
   .inline-code {

--- a/templates/components/Team/MemberModal.html.twig
+++ b/templates/components/Team/MemberModal.html.twig
@@ -6,7 +6,7 @@
     data-member-modal-member-value="{{ member.id.value }}"
     data-member-modal-prev-value="{{ prev }}"
     data-member-modal-next-value="{{ next }}"
-    data-action="cancel->member-modal#onCancel"
+    data-action="cancel->member-modal#onCancel keydown->member-modal#onKeydown"
     class="bg-transparent p-0 w-dvw max-w-none max-h-none h-dvh backdrop:bg-ink/55 backdrop:backdrop-blur-md"
 >
     <div
@@ -15,7 +15,7 @@
     >
         <div
             data-member-modal-target="modal"
-            class="relative w-full max-w-4xl max-h-[85dvh] flex flex-col bg-paper rounded-2xl overflow-hidden shadow-2xl transition-all ease-out duration-300 opacity-0 translate-y-4 scale-95"
+            class="relative w-full max-w-4xl h-[min(720px,85dvh)] grid grid-rows-[minmax(0,1fr)_auto] sm:grid-rows-[auto_minmax(0,1fr)_auto] bg-paper rounded-2xl overflow-hidden shadow-2xl transition-all ease-out duration-300"
         >
             <button
                 type="button"
@@ -34,28 +34,28 @@
                 >esc</button>
             </div>
 
-            <div class="flex-1 overflow-y-auto">
-                <div class="grid grid-cols-1 md:grid-cols-[18rem_1fr] md:min-h-[24rem]">
-                    <div class="relative overflow-hidden h-40 md:h-auto md:min-h-[14rem]">
-                        <img
-                            class="absolute inset-0 size-full scale-120 object-cover blur-2xl"
-                            src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
-                            alt=""
-                        />
-                        <div aria-hidden="true" class="absolute inset-0 bg-gradient-to-t from-ink via-ink/40 to-transparent"></div>
-                        <img
-                            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full max-h-[80%] max-w-[80%] shadow-lg"
-                            src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
-                            alt="Photo of {{ member.fullName }}"
-                        />
-                        {% if member.nickName %}
-                            <div class="absolute bottom-5 left-5 right-5 text-paper">
-                                <div class="font-sans italic text-paper/80 text-sm">“{{ member.nickName }}”</div>
-                            </div>
-                        {% endif %}
-                    </div>
+            <div class="grid min-h-0 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] md:grid-cols-[18rem_1fr] md:grid-rows-1 md:min-h-[24rem]">
+                <div class="relative overflow-hidden h-40 md:h-auto md:min-h-[14rem]">
+                    <img
+                        class="absolute inset-0 size-full scale-120 object-cover blur-2xl"
+                        src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
+                        alt=""
+                    />
+                    <div aria-hidden="true" class="absolute inset-0 bg-gradient-to-t from-ink via-ink/40 to-transparent"></div>
+                    <img
+                        class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full max-h-[80%] max-w-[80%] shadow-lg"
+                        src="{{ asset('images/team/members/' ~ member.id.value ~ '.webp') }}"
+                        alt="Photo of {{ member.fullName }}"
+                    />
+                    {% if member.nickName %}
+                        <div class="absolute bottom-5 left-5 right-5 text-paper">
+                            <div class="font-sans italic text-paper/80 text-sm">“{{ member.nickName }}”</div>
+                        </div>
+                    {% endif %}
+                </div>
 
-                    <div class="p-6 sm:p-8">
+                <div class="p-6 sm:p-8 grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto]">
+                    <div>
                         <h2
                             id="modal-title-{{ member.id.value }}"
                             class="mt-2 font-sans font-medium italic text-3xl sm:text-5xl tracking-tight text-ink leading-[0.95]"
@@ -63,16 +63,18 @@
                         <div class="mt-3 font-mono text-xs text-muted"><span class="text-ink">@{{ member.github }}</span></div>
 
                         <div class="rule-dotted my-5"></div>
+                    </div>
 
-                        <div
-                            id="modal-description-{{ member.id.value }}"
-                            class="font-article text-[0.96875rem] leading-[1.75] text-ink-soft text-pretty space-y-4"
-                        >
-                            {% for paragraph in ('team.bio.' ~ member.id.value)|trans|split('\n\n') %}
-                                <p>{{ paragraph|trim }}</p>
-                            {% endfor %}
-                        </div>
+                    <div
+                        id="modal-description-{{ member.id.value }}"
+                        class="overflow-y-auto scroll-fade font-article text-[0.96875rem] leading-[1.75] text-ink-soft text-pretty space-y-4"
+                    >
+                        {% for paragraph in ('team.bio.' ~ member.id.value)|trans|split('\n\n') %}
+                            <p>{{ paragraph|trim }}</p>
+                        {% endfor %}
+                    </div>
 
+                    <div>
                         <div class="rule-dotted my-5"></div>
 
                         <div class="flex flex-wrap items-center gap-1.5">


### PR DESCRIPTION
Minor improvements to make the crew modal more easy to use:
- Give the modal a fixed height (min(720px, 85dvh)) instead of sizing to content, so switching between members no longer changes the modal height
- Rewrite the inner layout from flexbox to CSS grid with explicit row tracks so only the bio paragraphs scroll, keeping photo, name, badges and social links fixed
- Add a scroll fade indicator on the bio using mask-image and scroll-driven animations
- Support Left/Right arrow keys to move between members, ignoring modifier combos so Alt+Arrow still triggers browser history
- Slide the member card sideways on Prev/Next instead of just swapping content, waiting for the outgoing slide to finish before opening the next dialog since only one dialog can be modal at a time

**Before:**

https://github.com/user-attachments/assets/3461c6de-80b0-4b95-91d3-144ab255beeb


**After:**



https://github.com/user-attachments/assets/e48b8f03-df30-43c3-8f97-b6d1cd2a2f90

